### PR TITLE
Update policy.go

### DIFF
--- a/pkg/window/policy.go
+++ b/pkg/window/policy.go
@@ -55,6 +55,7 @@ func (r *RollingPolicy) apply(f func(offset int, val float64), val float64) {
 
 	// calculate current offset
 	timespan := r.timespan()
+	oriTimespan := timespan
 	if timespan > 0 {
 		start := (r.offset + 1) % r.size
 		end := (r.offset + timespan) % r.size
@@ -64,7 +65,7 @@ func (r *RollingPolicy) apply(f func(offset int, val float64), val float64) {
 		// reset the expired buckets
 		r.window.ResetBuckets(start, timespan)
 		r.offset = end
-		r.lastAppendTime = r.lastAppendTime.Add(time.Duration(timespan * int(r.bucketDuration)))
+		r.lastAppendTime = r.lastAppendTime.Add(time.Duration(oriTimespan * int(r.bucketDuration)))
 	}
 	f(r.offset, val)
 }


### PR DESCRIPTION
修复当有新数据大于一个窗口时间加入的情况下，lastAppendTime的累加计算错误，最多只能累加一个窗口时间，时间会一直比当前时间小，导致进行统计分析Reduce的时候计算结果错误