### PR TITLE
fix: the Ceil method rounding calculations

### DIFF
--- a/ratelimit/bbr/bbr.go
+++ b/ratelimit/bbr/bbr.go
@@ -299,7 +299,7 @@ func (l *BBR) Allow() (ratelimit.DoneFunc, error) {
 	ms := float64(time.Millisecond)
 	return func(ratelimit.DoneInfo) {
 		//nolint
-		if rt := int64(math.Ceil(float64(time.Now().UnixNano()-start)) / ms); rt > 0 {
+		if rt := int64(math.Ceil(float64(time.Now().UnixNano()-start) / ms)); rt > 0 {
 			l.rtStat.Add(rt)
 		}
 		atomic.AddInt64(&l.inFlight, -1)


### PR DESCRIPTION
I found `calling math.Ceil on a converted integer is pointless (SA4015)`, so reviewed this expression and it seems to be wrong.