### PR TITLE
consistent_hash: fix threshold to shrink sortedHashed slice

### DIFF
--- a/internal/consistent/consistent.go
+++ b/internal/consistent/consistent.go
@@ -267,7 +267,7 @@ func (c *Consistent[M]) hashKeyFnv(key string) uint32 {
 func (c *Consistent[M]) updateSortedHashes() {
 	hashes := c.sortedHashes[:0]
 	//reallocate if we're holding on to too much (1/4th)
-	if cap(c.sortedHashes)/(c.NumberOfReplicas*4) > len(c.circle) {
+	if cap(c.sortedHashes)/(c.NumberOfReplicas*4) > len(c.members) {
 		hashes = nil
 	}
 	for k := range c.circle {


### PR DESCRIPTION
`len(c.circle)` equals the number of members * replication, while `len(c.members)` is the number of members. It seems the later one should be used here.